### PR TITLE
Added ability to create and delete roles

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,9 +11,10 @@ import (
 )
 
 type IAMGroupMapping struct {
-	LDAPGroup  string `yaml:"LDAPGroup"`
-	IAMPath    string `yaml:"IAMPath"`
-	ConsulPath string `yaml:"ConsulPath"`
+	LDAPGroup      string `yaml:"LDAPGroup"`
+	IAMPath        string `yaml:"IAMPath"`
+	ConsulPath     string `yaml:"ConsulPath"`
+	PrivilegeLevel string `yaml:"PrivilegeLevel"`
 }
 
 type Configuration struct {

--- a/config.go
+++ b/config.go
@@ -11,10 +11,9 @@ import (
 )
 
 type IAMGroupMapping struct {
-	LDAPGroup      string `yaml:"LDAPGroup"`
-	IAMPath        string `yaml:"IAMPath"`
-	ConsulPath     string `yaml:"ConsulPath"`
-	PrivilegeLevel string `yaml:"PrivilegeLevel"`
+	LDAPGroup  string `yaml:"LDAPGroup"`
+	IAMPath    string `yaml:"IAMPath"`
+	ConsulPath string `yaml:"ConsulPath"`
 }
 
 type Configuration struct {

--- a/iam.go
+++ b/iam.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
+	"log"
 )
 
 type CreateIAMUserResult struct {
@@ -137,4 +138,137 @@ func GetAllIAMUsers(config Configuration) (*iam.ListUsersOutput, error) {
 	//fmt.Println(resp)
 	return resp, nil
 
+}
+
+// Helper function to get ARN of a particular IAM user
+//
+// Example: arn, err := GetUserArn(conf, "test-user")
+func GetUserArn(config Configuration, username string) (Arn string, err error) {
+	sess := GetSession(config)
+	svc := iam.New(sess)
+
+	params := &iam.GetUserInput{
+		UserName: aws.String(username),
+	}
+	resp, err := svc.GetUser(params)
+	if err != nil {
+		log.Fatalf("User %s not found: %v", username, err.Error())
+		return "", err
+	}
+	return fmt.Sprintf("%s", *resp.User.Arn), nil
+}
+
+// Helper function to get arn of an IAM Role
+//
+// Example: arn, err := GetRoleArn(conf, "test-role")
+func GetRoleArn(config Configuration, rolename string) (Arn string, err error) {
+	sess := GetSession(config)
+	svc := iam.New(sess)
+
+	params := &iam.GetRoleInput{
+		RoleName: aws.String(rolename), // Required
+	}
+	resp, err := svc.GetRole(params)
+	if err != nil {
+		log.Fatalf("Role %s does not exist: %v", rolename, err.Error())
+		return "", err
+	}
+	return fmt.Sprintf("%s", *resp.Role.Arn), nil
+}
+
+// Create role
+func CreateRole(config Configuration, rolename string, userarn string, rolepath string) (*iam.CreateRoleOutput, error) {
+
+	sess := GetSession(config)
+	svc := iam.New(sess)
+
+	// Policy doc for this is a constant from the iam_roles.go file
+	policydoc := fmt.Sprintf(AssumeRolePolicy, userarn)
+	params := &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(policydoc), //required
+		RoleName:                 aws.String(rolename),
+		Path:                     aws.String(rolepath),
+	}
+	resp, err := svc.CreateRole(params)
+	if err != nil {
+		log.Fatalf("Unable to create role, role %s might already exist", rolename)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Attach an inline policy to the role
+//
+// Example: resp, err := AttachInlinePolicy(conf, rolepolicystring, "test-role")
+func AttachInlinePolicy(config Configuration, rolepolicy string, rolename string) (*iam.PutRolePolicyOutput, error) {
+
+	sess := GetSession(config)
+	svc := iam.New(sess)
+
+	// rolepolicy should be a json document
+	params := &iam.PutRolePolicyInput{
+		PolicyDocument: aws.String(rolepolicy), //required
+		PolicyName:     aws.String(rolename),
+		RoleName:       aws.String(rolename),
+	}
+	resp, err := svc.PutRolePolicy(params)
+	if err != nil {
+		log.Fatalf("Attach policy error: %v", err.Error())
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Attaches a readonly Policy to the IAM user, the Readonly policy
+// that we have is actually a managed policy that comes standard
+// with every AWS account
+//
+// Example: resp, err := AttachReadOnlyPolicy(conf, "testuser")
+func AttachReadOnlyPolicy(config Configuration, username string) (*iam.AttachUserPolicyOutput, error) {
+	sess := GetSession(config)
+	svc := iam.New(sess)
+
+	// Pretty sure this is a standard arn for readonly access
+	ReadOnlyArn := "arn:aws:iam::aws:policy/ReadOnlyAccess"
+	params := &iam.AttachUserPolicyInput{
+		PolicyArn: aws.String(ReadOnlyArn),
+		UserName:  aws.String(username),
+	}
+	resp, err := svc.AttachUserPolicy(params)
+	if err != nil {
+		log.Fatalf("Unable to attach readonly policy %s to user %s: %v", ReadOnlyArn, username, err.Error())
+		return nil, err
+	}
+	return resp, nil
+}
+
+func PolicyEnforcer(config Configuration, username string) {
+
+	// This is pretty inefficient
+	userarn := GetUserArn(config, username)
+	for _, x := range config.LdapServer.IAMGroupMapping {
+		priv := x.PrivilegeLevel
+		if priv == "admin" {
+			if noop {
+				log.Printf("NOOP: Will attempt to create role: %s with admin privilege", username)
+				log.Printf("Userarn: %s", userarn)
+			} else {
+				log.Printf("Calling CreateRole function")
+				//_, err := CreateRole(config, userarn)
+				//_, err := CreateRole(config, username, userarn, x.IAMPath)
+				//if err != nil {
+				//	log.Fatalf("Unable to create role: %s for user %s", username, username)
+				//}
+				//_, err := AttachInlinePolicy(config, AdminPolicy, username)
+			}
+
+		} else if priv == "readonly" {
+			if noop {
+				log.Printf("NOOP: Attempt to attach readonly role to user %s", username)
+			}
+
+		} else {
+			log.Fatalf("Invalid PrivelegeLevel value: %s", priv)
+		}
+	}
 }

--- a/iam.go
+++ b/iam.go
@@ -202,7 +202,7 @@ func AttachPolicy(config Configuration, rolearn string, rolename string) (*iam.A
 	svc := iam.New(sess)
 
 	params := &iam.AttachRolePolicyInput{
-		PolicyArn: aws.String(rolearn), // Required
+		PolicyArn: aws.String(rolearn),  // Required
 		RoleName:  aws.String(rolename), // Required
 	}
 
@@ -217,10 +217,10 @@ func AttachPolicy(config Configuration, rolearn string, rolename string) (*iam.A
 // Attaches a readonly policy to a role that we specify
 // The ReadOnlyPolicyArn is a constant value that comes with
 // every AWS account
-func AttachReadOnlyPolicy(rolename string) (*iam.AttachRolePolicyOutput, error) {
-	resp, err := AttachPolicy(ReadOnlyPolicyArn, rolename)
+func AttachReadOnlyPolicy(config Configuration, rolename string) (*iam.AttachRolePolicyOutput, error) {
+	resp, err := AttachPolicy(config, ReadOnlyPolicyArn, rolename)
 	if err != nil {
-		log.Fatalf("%v",err.Error())
+		log.Fatalf("%v", err.Error())
 		return nil, err
 	}
 	return resp, nil
@@ -229,21 +229,20 @@ func AttachReadOnlyPolicy(rolename string) (*iam.AttachRolePolicyOutput, error) 
 // Attaches an admin policy to a rolename
 // The Administrator Policy is a constant value
 // that comes with the AWS account
-func AttachAdminPolicy(rolename string) (*iam.AttachRolePolicyOutput, error) {
-	resp, err := AttachPolicy(AdminPolicyArn, rolename)
+func AttachAdminPolicy(config Configuration, rolename string) (*iam.AttachRolePolicyOutput, error) {
+	resp, err := AttachPolicy(config, AdminPolicyArn, rolename)
 	if err != nil {
-		log.Fatalf("%v": err.Error())
+		log.Fatalf("%v", err.Error())
 		return nil, err
 	}
 	return resp, nil
 }
 
-
 func PolicyEnforcer(config Configuration, username string) {
 	// This is pretty inefficient
 	for _, x := range config.LdapServer.IAMGroupMapping {
-		priv := x.PrivilegeLevel
-		if priv == "admin" {
+		IAMPath := x.IAMPath
+		if IAMPath == "/nubis/admin/" {
 			if noop {
 				log.Printf("NOOP: Will attempt to create role: %s with admin privilege", username)
 			} else {
@@ -256,13 +255,13 @@ func PolicyEnforcer(config Configuration, username string) {
 				//_, err := AttachInlinePolicy(config, AdminPolicy, username)
 			}
 
-		} else if priv == "readonly" {
+		} else if IAMPath == "/nubis/readonly/" {
 			if noop {
 				log.Printf("NOOP: Attempt to attach readonly role to user %s", username)
 			}
 
 		} else {
-			log.Fatalf("Invalid PrivelegeLevel value: %s", priv)
+			log.Fatalf("Invalid IAM path: %s", IAMPath)
 		}
 	}
 }

--- a/iam.go
+++ b/iam.go
@@ -152,10 +152,10 @@ func GetUserArn(config Configuration, username string) (Arn string, err error) {
 	}
 	resp, err := svc.GetUser(params)
 	if err != nil {
-		log.Fatalf("User %s not found: %v", username, err.Error())
+		log.Printf("User %s not found", username)
 		return "", err
 	}
-	return fmt.Sprintf("%s", *resp.User.Arn), nil
+	return *resp.User.Arn, nil
 }
 
 // Helper function to get arn of an IAM Role
@@ -170,7 +170,7 @@ func GetRoleArn(config Configuration, rolename string) (Arn string, err error) {
 	}
 	resp, err := svc.GetRole(params)
 	if err != nil {
-		log.Fatalf("Role %s does not exist: %v", rolename, err.Error())
+		log.Printf("Role %s does not exist", rolename)
 		return "", err
 	}
 	return fmt.Sprintf("%s", *resp.Role.Arn), nil
@@ -243,15 +243,12 @@ func AttachReadOnlyPolicy(config Configuration, username string) (*iam.AttachUse
 }
 
 func PolicyEnforcer(config Configuration, username string) {
-
 	// This is pretty inefficient
-	userarn := GetUserArn(config, username)
 	for _, x := range config.LdapServer.IAMGroupMapping {
 		priv := x.PrivilegeLevel
 		if priv == "admin" {
 			if noop {
 				log.Printf("NOOP: Will attempt to create role: %s with admin privilege", username)
-				log.Printf("Userarn: %s", userarn)
 			} else {
 				log.Printf("Calling CreateRole function")
 				//_, err := CreateRole(config, userarn)

--- a/iam_roles.go
+++ b/iam_roles.go
@@ -6,12 +6,24 @@ const AssumeRolePolicy = `{
        	{
             "Action": "sts:AssumeRole",
             "Principal": {
-       				"AWS": "%s"
+       			"AWS": "%s"
             },
             "Effect": "Allow",
         	"Sid": ""
         }
     ]
+}
+`
+
+const AdminPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
 }
 `
 

--- a/iam_roles.go
+++ b/iam_roles.go
@@ -15,14 +15,5 @@ const AssumeRolePolicy = `{
 }
 `
 
-const AdminPolicy = `{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "*",
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-`
+const AdminPolicyArn = "arn:aws:iam::aws:policy/AdministratorAccess"
+const ReadOnlyPolicyArn = "arn:aws:iam::aws:policy/ReadOnlyAccess"

--- a/iam_roles.go
+++ b/iam_roles.go
@@ -1,0 +1,28 @@
+package main
+
+const AssumeRolePolicy = `{
+    "Version": "2012-10-17",
+    "Statement": [
+       	{
+            "Action": "sts:AssumeRole",
+            "Principal": {
+       				"AWS": "%s"
+            },
+            "Effect": "Allow",
+        	"Sid": ""
+        }
+    ]
+}
+`
+
+const AdminPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "*",
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+`

--- a/main.go
+++ b/main.go
@@ -160,6 +160,7 @@ func main() {
 				if IgnoreUser(iamUsers, user) == false {
 					if noop == true {
 						log.Printf("NOOP: Adding: %s to iamUsers", user)
+						PolicyEnforcer(configuration, user)
 					} else {
 						path := userPathList.getPathByUsername(user)
 						userRet, err := CreateIAMUser(configuration, user, path)

--- a/main.go
+++ b/main.go
@@ -165,11 +165,13 @@ func main() {
 						path := userPathList.getPathByUsername(user)
 						log.Printf("Creating user: %s at path: %s", user, path)
 						userRet, err := CreateIAMUser(configuration, user, path)
+						// Reason this needs to be here is because sometimes a user gets created
+						// by AWS but it doesn't show up immediately
 						time.Sleep(5 * time.Second)
 						if err != nil {
 							log.Fatal(err)
 						}
-						PolicyEnforcer(configuration, user, path)
+						ApplyRoles(configuration, user, path)
 						userLDAPObj, found := GetLDAPUserObjectFromGroup(user, allLDAPGroupUserObjects)
 						fmt.Println(len(userLDAPObj.PGPPublicKey))
 						continue
@@ -198,9 +200,11 @@ func main() {
 				if noop == true {
 					log.Printf("NOOP: Removing: %s from iamUsers", user)
 				} else {
+					DetachGroup(configuration, user)
 					_, deletedErr := DeleteIAMUser(configuration, user)
 					if deletedErr == nil {
 						log.Printf("Removing: %s from iamUsers", user)
+						DeleteRoles(configuration, user)
 					}
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 )
 
 var (
@@ -160,13 +161,15 @@ func main() {
 				if IgnoreUser(iamUsers, user) == false {
 					if noop == true {
 						log.Printf("NOOP: Adding: %s to iamUsers", user)
-						PolicyEnforcer(configuration, user)
 					} else {
 						path := userPathList.getPathByUsername(user)
+						log.Printf("Creating user: %s at path: %s", user, path)
 						userRet, err := CreateIAMUser(configuration, user, path)
+						time.Sleep(5 * time.Second)
 						if err != nil {
 							log.Fatal(err)
 						}
+						PolicyEnforcer(configuration, user, path)
 						userLDAPObj, found := GetLDAPUserObjectFromGroup(user, allLDAPGroupUserObjects)
 						fmt.Println(len(userLDAPObj.PGPPublicKey))
 						continue


### PR DESCRIPTION
This PR does a couple of things

1. It will create roles based on where the user path
2. Each role will get a policy attached to it and be added to the groups that it needs to be in (right now we are just using 2 groups)
3. Will also delete the roles and remove users from groups when its no longer listed

Fixes issue #27